### PR TITLE
issue #1: fix crc-16, crc-32, crc-64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.so
 *.gcda
 *.clangtidy
+/.*project
+/.settings/

--- a/Doxyfile
+++ b/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -843,7 +843,6 @@ FILE_PATTERNS          = *.c \
                          *.inc \
                          *.m \
                          *.markdown \
-                         *.md \
                          *.mm \
                          *.dox \
                          *.py \


### PR DESCRIPTION
The issue was that the index to the LUT was actually coming from the LSB of the LFSR when it should have been coming from the MSB.

Found the correction on the wikipedia.

Adjusted API a bit, added sanity testing, input validation (where possible).

API modifications
* crcx() no longer calls crcx_init() or crcx_fini() - those must be called by the application
* modified some return values - bools for success
* added crcx_valid() to check crcx_ctx validity
* added ASSERT_TRUE() to tests where return value is bool (for success)