### PR TITLE
issue 11: Add some BLE test cases

### DIFF
--- a/src/crcx.h
+++ b/src/crcx.h
@@ -176,8 +176,7 @@ void crcx_update(struct crcx_ctx *ctx, const uint8_t data);
  * @p len times, once for each item in @p data.
  *
  * Typical uses cases of CRCx will use this function along with @ref crcx_init
- * and
- * @ref crcx_fini. However, doing so is simply a shorthand. It is entirely
+ * and @ref crcx_fini. However, doing so is simply a shorthand. It is entirely
  * possible
  * to call @ref crcx_update directly without the use of this function.
  *


### PR DESCRIPTION
The first test case came from data collected on my own with a particular BLE 5.2 radio. When hardware CRC filtering is enabled for this particular radio, no packets are received. It appears that there is a silicon bug.

The second test case came from here:

https://devzone.nordicsemi.com/f/nordic-q-a/679/ble-crc-calculation

The third test case came from the

BLE 5.2 Specification
  Vol 6: Core System Package[Low Energy Controller]
    Part C: Complete Packets
      Section 4.2.1: Legacy advertising PDUs