### PR TITLE
Add a proper C++ API

### DIFF
--- a/.scripts/build-and-install-libgtest-libraries.sh
+++ b/.scripts/build-and-install-libgtest-libraries.sh
@@ -14,7 +14,7 @@ cd googletest
 
 # installs headers to /usr/include/gtest /usr/include/gmock
 # install static libraries to /usr/lib
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr . && make -j$(nproc --all) all install
+cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX:PATH=/usr . && make -j$(nproc --all) all install
 # install shared libraries to /usr/lib
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=ON && make -j$(nproc --all) all install
+cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=ON && make -j$(nproc --all) all install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ script:
   - # ensure a simple application can compile and link to libcrcx
   - echo 'extern void crcx_init(); int main() { crcx_init(); return 0; }' > foo.c
   - gcc -o foo foo.c `pkg-config --cflags --libs crcx`
+  - # ensure a simple application can compile and link to libcrcxxx
+  - echo '#include <crcx/crcxxx.h>' > foo.cpp
+  - echo 'using namespace ::crcx; int main() { using Crcx = Crc<8,uint8_t,7>; Crcx crc(0,0,false,false); return 0; }' >> foo.cpp
+  - g++ -o foo foo.cpp `pkg-config --cflags --libs crcxxx`
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
 AC_PROG_CC_C11
-#AX_CXX_COMPILE_STDCXX_11
+AX_CXX_COMPILE_STDCXX(14, noext)
 
 PKG_INSTALLDIR
 
@@ -31,7 +31,7 @@ AC_ARG_WITH(
         [gtest],
         [AS_HELP_STRING(
                 [--with-gtest],
-                [Enable gtest for unit and integration testing]
+                [Enable gtest for unit and integration testing (auto)]
         )]
 )
 AS_IF(
@@ -57,6 +57,21 @@ AS_IF(
         ])
 ])
 AM_CONDITIONAL([HAVE_GTEST],[test "x$have_gtest" = "xyes"])
+
+with_cxx="auto"
+AC_ARG_WITH(
+        [cxx],
+        [AS_HELP_STRING(
+                [--with-cxx],
+                [Build C++ Library (auto)]
+        )]
+)
+AS_IF(
+        [test "x$with_cxx" != "xno"],
+        [have_cxx=yes],
+        [have_cxx=no]
+)
+AM_CONDITIONAL([HAVE_CXX],[test "x$have_cxx" = "xyes"])
 
 # Checks for header files.
 AC_CHECK_HEADERS([inttypes.h stddef.h stdint.h string.h])
@@ -87,6 +102,7 @@ fi
 fi
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([docs/Doxyfile])])
+AS_IF([test "x$have_cxx" = "xyes"], [AC_CONFIG_FILES([src/crcxxx.pc])])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -9,8 +9,7 @@ html: doxyfile.stamp
 CLEANFILES =           \
 	doxyfile.stamp \
 	html           \
-	latex          \
-	Doxyfile
+	latex
 
 all-local: doxyfile.stamp
 

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,951 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual ~Base() {}
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual ~Derived() override {}
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
+
+]])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,14 +1,21 @@
 lib_LTLIBRARIES =  \
-	libcrcx.la
+	libcrcx.la     \
+	libcrcxxx.la
+
+libcrcxxx_la_SOURCES = \
+	crcxxx.cpp
+crcxxx_cpp_CXXFLAGS = \
+	-Wall -Wextra -Werror
 
 libcrcx_la_SOURCES = \
 	crcx.c
-
 crcx_c_CFLAGS = \
 	-Wall -Wextra -Werror
 
 nobase_include_HEADERS = \
-	crcx/crcx.h
+	crcx/crcx.h          \
+	crcx/crcxxx.h
 
 pkgconfig_DATA = \
-	crcx.pc
+	crcx.pc      \
+	crcxxx.pc

--- a/src/crcx/crcxxx.h
+++ b/src/crcx/crcxxx.h
@@ -1,0 +1,144 @@
+#ifndef CRCXXX_H_
+#define CRCXXX_H_
+
+#include <array>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+
+namespace crcx {
+
+// See https://stackoverflow.com/a/19016627
+template <size_t... Is> struct seq {};
+template <size_t N, size_t... Is>
+struct gen_seq : gen_seq<N - 1, N - 1, Is...> {};
+template <size_t... Is> struct gen_seq<0, Is...> : seq<Is...> {};
+
+template <class Generator, std::size_t... Is>
+constexpr auto generate_array_helper(Generator g, seq<Is...>)
+    -> std::array<decltype(g(std::size_t{})), sizeof...(Is)> {
+  return {{g(Is)...}};
+}
+
+template <std::size_t N, class Generator>
+constexpr auto generate_array(Generator g)
+    -> decltype(generate_array_helper(g, gen_seq<N>{})) {
+  return generate_array_helper(g, gen_seq<N>{});
+}
+
+template <typename T>
+constexpr T reflect(const T &x, const size_t & N = 8 * sizeof(T)) {
+
+  const size_t n = std::min( N, 8 * sizeof(T) );
+
+  T y = 0;
+
+  for (size_t i = 0; i < n; ++i) {
+    bool bit = (x >> i) & 1;
+    y |= bit << ((n - 1) - i);
+  }
+
+  return y;
+}
+
+template <typename T, std::size_t N, std::uintmax_t polynomial>
+struct generator {
+
+  static constexpr void checkTemplateParameters() {
+    static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+    static_assert(0 != N, "CRC length must be non-zero");
+    static_assert(0 == N % 8, "CRC length must be a multiple of 8");
+    static_assert(N <= 8 * sizeof(T), "CRC length must be <= 8 * sizeof(T)");
+    static_assert(T(0) != polynomial, "CRC polynomial must be non-zero");
+    static_assert(T(0) == (polynomial & (~mask())),
+                  "CRC polynomial must be N bits");
+  }
+
+  static constexpr T msb() {
+    static_assert(N <= 8 * sizeof(T), "CRC length must be <= 8 * sizeof(T)");
+    return T(1ULL << (N - 1));
+  }
+
+  static constexpr T mask() {
+    static_assert(N <= 8 * sizeof(T), "CRC length must be <= 8 * sizeof(T)");
+    if (N == 8 * sizeof(T)) {
+      return T(-1);
+    } else {
+      return T((1ULL << N) - 1);
+    }
+  }
+
+  static constexpr T func(T x) {
+
+    checkTemplateParameters();
+
+    T index = (x << (N - 8)) & mask();
+    for (auto bit = 0; bit < 8; ++bit) {
+      if (0 != (index & msb())) {
+        index <<= 1;
+        index ^= polynomial;
+      } else {
+        index <<= 1;
+      }
+    }
+
+    return index & mask();
+  }
+};
+
+template <std::size_t N, typename T, std::uintmax_t polynomial> class Crc {
+public:
+  Crc(T initializer, T finalizer, bool reflectInput, bool reflectOutput)
+      : initializer(initializer), finalizer(finalizer),
+        reflectInput(reflectInput), reflectOutput(reflectOutput),
+        lfsr(initializer) {}
+
+  void update(uint8_t data) {
+
+    if (reflectInput) {
+      data = reflect(data,8);
+    }
+
+    // https://en.wikipedia.org/wiki/Computation_of_cyclic_redundancy_checks#Multi-bit_computation
+    uint8_t upper_byte = (lfsr >> (N - 8));
+    uint8_t idx = data ^ upper_byte;
+
+    lfsr <<= 8;
+    lfsr &= generator<T, N, polynomial>::mask();
+    lfsr ^= table[idx];
+  }
+
+  template <class iterator_type>
+  void update(iterator_type begin, iterator_type end) {
+    for (auto it = begin; it != end; it++) {
+      update(*it);
+    }
+  }
+
+  T fini() {
+    lfsr ^= finalizer;
+    lfsr &= generator<T, N, polynomial>::mask();
+
+    if (reflectOutput) {
+      return reflect(lfsr, N);
+    } else {
+      return lfsr;
+    }
+  }
+
+  // C++17 removes the need for inline here
+  inline static constexpr auto table =
+      generate_array<256>(&generator<T, N, polynomial>::func);
+
+protected:
+  const T initializer;
+  const T finalizer;
+  const bool reflectInput;
+  const bool reflectOutput;
+
+  T lfsr;
+};
+
+} /* namespace crcx */
+
+#endif /* CRCXXX_H_ */

--- a/src/crcxxx.cpp
+++ b/src/crcxxx.cpp
@@ -1,0 +1,10 @@
+#include "crcx/crcxxx.h"
+
+using namespace crcx;
+// using namespace std;
+
+namespace crcx {
+
+void empty() {}
+
+} /* namespace crcx */

--- a/src/crcxxx.pc.in
+++ b/src/crcxxx.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@exec_prefix@/lib
+includedir=@prefix@/include
+
+Name: @PACKAGE_NAME@xx
+Description: Yet Another CRC Library (C++ API)
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -l@PACKAGE_NAME@xx
+Cflags: -I${includedir}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,12 +1,11 @@
 noinst_PROGRAMS =
 
-AM_CPPFLAGS = -I@top_srcdir@/src
+AM_CPPFLAGS = -I@top_srcdir@/src/
 
 AM_CFLAGS = @GTEST_CFLAGS@
 
-LDADD = \
-	@top_srcdir@/src/lib@PACKAGE_NAME@.la \
-        @GTEST_LIBS@
+AM_LDADD = \
+	@GTEST_LIBS@
 
 if HAVE_GTEST
 
@@ -14,7 +13,13 @@ if HAVE_GTEST
 
 noinst_PROGRAMS += crcx-test
 crcx_test_SOURCES = crcx-test.cpp
-crcx_test_LDLIBS = @GTEST_LIBS@
+crcx_test_LDADD= @top_srcdir@/src/lib@PACKAGE_NAME@.la $(AM_LDADD)
+
+if HAVE_CXX
+noinst_PROGRAMS += crcxxx-test
+crcxxx_test_SOURCES = crcxxx-test.cpp
+crcxxx_test_LDADD = @top_srcdir@/src/lib@PACKAGE_NAME@xx.la $(AM_LDADD)
+endif
 
 check-local:
 	$(MAKE) gtest

--- a/test/crcx-test.cpp
+++ b/test/crcx-test.cpp
@@ -210,9 +210,17 @@ TEST(Sanity, invalid_param_to_crcx_init) {
   ASSERT_FALSE(::crcx_init(&ctx, 1, 0, 0, 0x7, false, false));
 }
 
-TEST(Sanity, invalid_ctx_to_crcx_fini) { ASSERT_EQ(::crcx_fini(nullptr), -1); }
+// clang-format off
+TEST(Sanity, invalid_ctx_to_crcx_fini) {
+	ASSERT_EQ(::crcx_fini(nullptr), -1);
+}
+// clang-format on
 
-TEST(Sanity, invalid_ctx_to_crcx) { ASSERT_FALSE(::crcx(nullptr, nullptr, 0)); }
+// clang-format off
+TEST(Sanity, invalid_ctx_to_crcx) {
+	ASSERT_FALSE(::crcx(nullptr, nullptr, 0));
+}
+// clang-format on
 
 // This test shows that the CRC works for a single byte.
 // It also tests to make sure that the input parameters are set accordingly.
@@ -762,7 +770,12 @@ TEST(CRCx, nrf_support1) {
       .addr =
           {
               // note, this is least-significant byte first
-              0x0d, 0xef, 0x84, 0xb7, 0x2d, 0x3c,
+              0x0d,
+              0xef,
+              0x84,
+              0xb7,
+              0x2d,
+              0x3c,
           },
       .data =
           {
@@ -798,7 +811,12 @@ TEST(CRCx, ble_core_52_4_2_1_Legacy_Advertising_PDUs) {
       .addr =
           {
               // note, this is least-significant byte first
-              0xa6, 0xa5, 0xa4, 0xa3, 0xa2, 0xc1,
+              0xa6,
+              0xa5,
+              0xa4,
+              0xa3,
+              0xa2,
+              0xc1,
           },
       .data =
           {

--- a/test/crcxxx-test.cpp
+++ b/test/crcxxx-test.cpp
@@ -1,0 +1,439 @@
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "crcx/crcxxx.h"
+
+using namespace std;
+using namespace crcx;
+
+// This test shows that the CRC works for a single byte.
+// It also tests to make sure that the input parameters are set accordingly.
+// Also, it checks that the LUT is generated correctly.
+TEST(CRCx, Wikipedia_example1) {
+  // https://en.wikipedia.org/wiki/Computation_of_cyclic_redundancy_checks#Example
+  // compute the 8-bit CRC of the ascii character 'W' (0b01010111, 0x57, 87)
+  // CRC-8-ATM (HEC) polynomial x^8 + x^2 + x + 1 => '100000111'
+
+  using Crcx = Crc<8, uint8_t, 0x7>;
+
+  Crcx crc(0, 0, false, false);
+
+  // This site has a table generator and gives the same output as the wikipedia
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // clang-format off
+  decltype(Crcx::table) expected_table = {
+	0x00, 0x07, 0x0E, 0x09, 0x1C, 0x1B, 0x12, 0x15, 0x38, 0x3F, 0x36, 0x31, 0x24, 0x23, 0x2A, 0x2D,
+    0x70, 0x77, 0x7E, 0x79, 0x6C, 0x6B, 0x62, 0x65, 0x48, 0x4F, 0x46, 0x41, 0x54, 0x53, 0x5A, 0x5D,
+    0xE0, 0xE7, 0xEE, 0xE9, 0xFC, 0xFB, 0xF2, 0xF5, 0xD8, 0xDF, 0xD6, 0xD1, 0xC4, 0xC3, 0xCA, 0xCD,
+    0x90, 0x97, 0x9E, 0x99, 0x8C, 0x8B, 0x82, 0x85, 0xA8, 0xAF, 0xA6, 0xA1, 0xB4, 0xB3, 0xBA, 0xBD,
+    0xC7, 0xC0, 0xC9, 0xCE, 0xDB, 0xDC, 0xD5, 0xD2, 0xFF, 0xF8, 0xF1, 0xF6, 0xE3, 0xE4, 0xED, 0xEA,
+    0xB7, 0xB0, 0xB9, 0xBE, 0xAB, 0xAC, 0xA5, 0xA2, 0x8F, 0x88, 0x81, 0x86, 0x93, 0x94, 0x9D, 0x9A,
+    0x27, 0x20, 0x29, 0x2E, 0x3B, 0x3C, 0x35, 0x32, 0x1F, 0x18, 0x11, 0x16, 0x03, 0x04, 0x0D, 0x0A,
+    0x57, 0x50, 0x59, 0x5E, 0x4B, 0x4C, 0x45, 0x42, 0x6F, 0x68, 0x61, 0x66, 0x73, 0x74, 0x7D, 0x7A,
+    0x89, 0x8E, 0x87, 0x80, 0x95, 0x92, 0x9B, 0x9C, 0xB1, 0xB6, 0xBF, 0xB8, 0xAD, 0xAA, 0xA3, 0xA4,
+    0xF9, 0xFE, 0xF7, 0xF0, 0xE5, 0xE2, 0xEB, 0xEC, 0xC1, 0xC6, 0xCF, 0xC8, 0xDD, 0xDA, 0xD3, 0xD4,
+    0x69, 0x6E, 0x67, 0x60, 0x75, 0x72, 0x7B, 0x7C, 0x51, 0x56, 0x5F, 0x58, 0x4D, 0x4A, 0x43, 0x44,
+    0x19, 0x1E, 0x17, 0x10, 0x05, 0x02, 0x0B, 0x0C, 0x21, 0x26, 0x2F, 0x28, 0x3D, 0x3A, 0x33, 0x34,
+    0x4E, 0x49, 0x40, 0x47, 0x52, 0x55, 0x5C, 0x5B, 0x76, 0x71, 0x78, 0x7F, 0x6A, 0x6D, 0x64, 0x63,
+    0x3E, 0x39, 0x30, 0x37, 0x22, 0x25, 0x2C, 0x2B, 0x06, 0x01, 0x08, 0x0F, 0x1A, 0x1D, 0x14, 0x13,
+    0xAE, 0xA9, 0xA0, 0xA7, 0xB2, 0xB5, 0xBC, 0xBB, 0x96, 0x91, 0x98, 0x9F, 0x8A, 0x8D, 0x84, 0x83,
+    0xDE, 0xD9, 0xD0, 0xD7, 0xC2, 0xC5, 0xCC, 0xCB, 0xE6, 0xE1, 0xE8, 0xEF, 0xFA, 0xFD, 0xF4, 0xF3,
+  };
+  // clang-format on
+
+  auto &actual_table = Crcx::table;
+
+  ASSERT_EQ(actual_table, expected_table) << "The generated table is incorrect";
+
+  crc.update(uint8_t('W'));
+
+  auto expected = 0xa2;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that multi-byte input CRC works
+TEST(CRCx, Sunshine_CRC8) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC8
+  // input not reflected
+  // result not reflected
+  // polynomial 0x07 => x^8 + x^2 + x + 1
+  // initial value: 0
+  // final xor value: 0
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<8, uint8_t, 0x7>;
+
+  Crcx crc(0, 0, false, false);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0xf4;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that the final xor value is applied
+TEST(CRCx, Sunshine_CRC8_ITU) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC8_ITU
+  // input not reflected
+  // result not reflected
+  // polynomial 0x07 => x^8 + x^2 + x + 1
+  // initial value: 0
+  // final xor value: 0x55
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<8, uint8_t, 0x7>;
+
+  Crcx crc(0, 0x55, false, false);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0xa1;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that input and output reflection works
+TEST(CRCx, Sunshine_CRC8_DARC) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC8_DARC
+  // input reflected
+  // result reflected
+  // polynomial 0x39 => x^8 + 1x^5 + 1x^4 + 1x^3 1x
+  // initial value: 0
+  // final xor value: 0
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<8, uint8_t, 0x39>;
+
+  Crcx crc(0, 0, true, true);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0x15;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that CRC16 works for one byte messages
+TEST(CRCx, Sunshine_CRC16_CCIT_ZERO_one_byte) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC16_CCIT_ZERO
+  // input not reflected
+  // result not reflected
+  // polynomial 0x1021
+  // initial value: 0
+  // final xor value: 0
+  // CRC Input Data: 'W'
+
+  using Crcx = Crc<16, uint16_t, 0x1021>;
+
+  Crcx crc(0, 0, false, false);
+
+  const vector<uint8_t> data{'W'};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0x2a12;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that CRC16 works
+TEST(CRCx, Sunshine_CRC16_CCIT_ZERO) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC16_CCIT_ZERO
+  // input not reflected
+  // result not reflected
+  // polynomial 0x1021
+  // initial value: 0
+  // final xor value: 0
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<16, uint16_t, 0x1021>;
+
+  Crcx crc(0, 0, false, false);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0x31c3;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that CRC32 works
+TEST(CRCx, Sunshine_CRC32_POSIX) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC32_POSIX
+  // input not reflected
+  // result not reflected
+  // polynomial 0x4c11db7
+  // initial value: 0
+  // final xor value: -1
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<32, uint32_t, 0x4c11db7>;
+
+  Crcx crc(0, -1, false, false);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0x765e7680;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+// this test shows that CRC64 works
+TEST(CRCx, Sunshine_CRC64_ECMA_182) {
+  // http://www.sunshine2k.de/coding/javascript/crc/crc_js.html
+  // CRC64_ECMA_182
+  // input not reflected
+  // result not reflected
+  // polynomial 0x4c11db7
+  // initial value: 0
+  // final xor value: 0
+  // CRC Input Data: 0x31 0x32 0x33 0x34 0x35 0x36 0x37 0x38 0x39
+
+  using Crcx = Crc<64, uint64_t, 0x42F0E1EBA9EA3693>;
+
+  Crcx crc(0, 0, false, false);
+
+  const vector<uint8_t> data{0x31, 0x32, 0x33, 0x34, 0x35,
+                             0x36, 0x37, 0x38, 0x39};
+
+  crc.update(data.begin(), data.end());
+
+  auto expected = 0x6c40df5f0b497347;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected) << "The calculated CRC is incorrect";
+}
+
+TEST(CRCx, reflect24) {
+  uintmax_t expected_uintmax = 0xabcdef;
+  uintmax_t actual_uintmax = reflect(0xf7b3d5,24);
+
+  EXPECT_EQ(actual_uintmax, expected_uintmax)
+      << "expected: " << hex << setw(6) << setfill('0') << expected_uintmax
+      << "actual:   " << hex << setw(6) << setfill('0') << actual_uintmax;
+}
+
+// BLE CRC polynomial is  x^24 + x^10 + x^9 + x^6 + x^4 + x^3 + x + 1
+// This corresponds to 0x[1]00065b
+// In the advertising channel, the BLE CRC initializer is 0x555555
+
+const size_t ble_crc_n = 24;
+const uintmax_t ble_poly(0x00065b);
+const uintmax_t ble_init(0x555555);
+const uintmax_t ble_fini(0);
+const bool ble_reflect_input = true;
+const bool ble_reflect_output = false;
+
+enum {
+  ADV_IND = 0x0,
+  ADV_NONCONN_IND = 0x2,
+  BDADDR_SIZE = 6,
+  PDU_AC_LL_HEADER_SIZE = 2,
+  ADV_DATA_LEN = 31,
+};
+
+// adapted from Zephyr
+struct pdu_adv {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint8_t type : 4;
+  uint8_t rfu : 1;
+  uint8_t chan_sel : 1;
+  uint8_t tx_addr : 1;
+  uint8_t rx_addr : 1;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  uint8_t rx_addr : 1;
+  uint8_t tx_addr : 1;
+  uint8_t chan_sel : 1;
+  uint8_t rfu : 1;
+  uint8_t type : 4;
+#else
+#error "Unsupported endianness"
+#endif
+
+  uint8_t len;
+
+  // for adv_ind
+  uint8_t addr[BDADDR_SIZE];
+  uint8_t data[ADV_DATA_LEN];
+} __attribute__((packed));
+
+TEST(CRCx, board_example1) {
+
+  vector<uint8_t> rxbuf{{0x2c, 0xc5, 0x22, 0x44, 0x05, 0x6b, 0x8e, 0x55, 0x6b,
+                         0xcd, 0xde, 0x1e, 0xb0, 0x6f, 0xc0, 0x4a, 0x85, 0x7b,
+                         0x29, 0x32, 0x18, 0x8d, 0x02, 0x0a, 0x00, 0x24, 0x00,
+                         0x00, 0x00, 0xf4, 0x01, 0x00, 0xfe, 0xff, 0xff, 0x1f,
+                         0x08, 0x10, 0x80, 0xbd, 0xcb, 0x1d, 0x98, 0x94, 0x06}};
+
+  size_t offs = rxbuf[0];
+  uint8_t *data = &rxbuf[1];
+
+  uint32_t timestamp = 0;
+
+  timestamp |= data[--offs] << 24;
+  timestamp |= data[--offs] << 16;
+  timestamp |= data[--offs] << 8;
+  timestamp |= data[--offs] << 0;
+
+  ASSERT_EQ(110401565, timestamp);
+
+  int8_t rssi = int8_t(data[--offs]);
+  ASSERT_EQ(rssi, -53);
+
+  uint32_t hw_crc = 0;
+
+  hw_crc |= data[--offs] << 16;
+  hw_crc |= data[--offs] << 8;
+  hw_crc |= data[--offs] << 0;
+
+  size_t len = offs;
+
+  const size_t pdu_len = PDU_AC_LL_HEADER_SIZE + len;
+
+  const uint32_t wireshark_crc(0x0801bd);
+
+  using Crcx = Crc<ble_crc_n, uint32_t, uint32_t(ble_poly)>;
+  Crcx crc(uint32_t(ble_init), uint32_t(ble_fini), ble_reflect_input, ble_reflect_output);
+  crc.update(data, data + len);
+  uintmax_t sw_crc = crc.fini();
+
+  /* When hardware CRC checking (filtering) is enabled on this radio, no packets
+   * are received beyond the advertising packets.
+   * When hardware CRC filtering is disabled on this radio, packets are received
+   * beyond advertising packets, but the
+   * crc reported by the radio is incorrect. It would seem that the CRC hardware
+   * is not being properly configured.
+   */
+
+  // When comparing for EQ, fails with message HW CRC (bd8010) does not match
+  // Wireshark CRC (0801bd)
+  EXPECT_NE(hw_crc, wireshark_crc)
+      << "HW CRC (" << hex << setw(6) << setfill('0') << hw_crc
+      << ") does not match Wireshark CRC (" << hex << setw(6) << setfill('0')
+      << wireshark_crc << ")";
+
+  // Succeeds
+  EXPECT_EQ(sw_crc, wireshark_crc)
+      << "SW CRC (" << hex << setw(6) << setfill('0') << sw_crc
+      << ") does not match Wireshark CRC (" << hex << setw(6) << setfill('0')
+      << wireshark_crc << ")";
+
+  // When comparing for EQ, fails with message SW CRC (0801bd) does not match HW
+  // CRC (bd8010)
+  EXPECT_NE(sw_crc, hw_crc) << "SW CRC (" << hex << setw(6) << setfill('0')
+                            << sw_crc << ") does not match HW CRC (" << hex
+                            << setw(6) << setfill('0') << hw_crc << ")";
+}
+
+TEST(CRCx, nrf_support1) {
+  // https://devzone.nordicsemi.com/f/nordic-q-a/679/ble-crc-calculation
+
+  const struct pdu_adv pdu = {
+      .type = ADV_IND,
+      .rfu = 0,
+      .chan_sel = 0,
+      .tx_addr = 0,
+      .rx_addr = 0,
+      .len = 9,
+      .addr =
+          {
+              // note, this is least-significant byte first
+              0x0d,
+              0xef,
+              0x84,
+              0xb7,
+              0x2d,
+              0x3c,
+          },
+      .data =
+          {
+              0x02, 0x01, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+              0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          },
+  };
+  const size_t pdu_len = PDU_AC_LL_HEADER_SIZE + pdu.len;
+
+  using Crcx = Crc<ble_crc_n, uint32_t, uint32_t(ble_poly)>;
+  Crcx crc(uint32_t(ble_init), uint32_t(ble_fini), ble_reflect_input, ble_reflect_output);
+  crc.update((uint8_t *)&pdu, ((uint8_t *)&pdu) + pdu_len);
+
+  uintmax_t expected_uintmax = reflect(0xa4e2c2, ble_crc_n);
+  uintmax_t actual_uintmax = crc.fini();
+
+  EXPECT_EQ(actual_uintmax, expected_uintmax)
+      << "expected: " << hex << setw(6) << setfill('0') << expected_uintmax
+      << " "
+      << "actual: " << hex << setw(6) << setfill('0') << actual_uintmax << " ";
+}
+
+TEST(CRCx, ble_core_52_4_2_1_Legacy_Advertising_PDUs) {
+  // https://www.bluetooth.com/specifications/bluetooth-core-specification/
+
+  const struct pdu_adv pdu = {
+      .type = ADV_NONCONN_IND,
+      .rfu = 0,
+      .chan_sel = 0,
+      .tx_addr = 1,
+      .rx_addr = 0,
+      .len = 9,
+      .addr =
+          {
+              // note, this is least-significant byte first
+              0xa6,
+              0xa5,
+              0xa4,
+              0xa3,
+              0xa2,
+              0xc1,
+          },
+      .data =
+          {
+              0x01, 0x02, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+              0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          },
+  };
+  const size_t pdu_len = PDU_AC_LL_HEADER_SIZE + pdu.len;
+
+  using Crcx = Crc<ble_crc_n, uint32_t, uint32_t(ble_poly)>;
+  Crcx crc(uint32_t(ble_init), uint32_t(ble_fini), ble_reflect_input, ble_reflect_output);
+  crc.update((uint8_t *)&pdu, ((uint8_t *)&pdu) + pdu_len);
+
+  auto expected = 0xb52dd7;
+  auto actual = crc.fini();
+
+  EXPECT_EQ(actual, expected)
+      << "expected: " << hex << setw(6) << setfill('0') << expected
+      << " "
+      << "actual: " << hex << setw(6) << setfill('0') << actual << " ";
+}


### PR DESCRIPTION
* added cxx m4
* added src/crcx/crcxxx.h
* added test/crcxxx-test.cpp
* added post-install build check

Could probably improve the reflect algorithm a bit more. At first I was using a template specialization for uint8_t with a LUT, but that didn't work (possibly uint8_t was promoted to uint32_t?).
