### PR TITLE
issue 47: fix macos build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
             - cmake
             - lcov
       env:
-        - MATRIX_EVAL="SUDO=sudo && MAKE=make && OPTS='--enable-code-coverage'"
+        - MATRIX_EVAL="SUDO=sudo && MAKE=make"
     - os: linux
       arch: s390x
       sudo: required
@@ -45,7 +45,7 @@ matrix:
             - cmake
             - lcov
       env:
-        - MATRIX_EVAL="SUDO=sudo && MAKE=make && OPTS='--enable-code-coverage'"
+        - MATRIX_EVAL="SUDO=sudo && MAKE=make"
     - os: linux
       arch: arm64
       sudo: required
@@ -58,16 +58,15 @@ matrix:
             - cmake
             - lcov
       env:
-        - MATRIX_EVAL="SUDO=sudo && MAKE=make && OPTS='--enable-code-coverage --without-doxygen'"
+        - MATRIX_EVAL="SUDO=sudo && MAKE=make"
     - os: osx
       osx_image: xcode11.3
       addons:
         homebrew:
           packages:
             - autoconf-archive
-            - lcov
       env:
-        - MATRIX_EVAL="SUDO=sudo && MAKE=make && OPTS='--enable-code-coverage --without-doxygen'"
+        - MATRIX_EVAL="SUDO=sudo && MAKE=make"
     - os: windows
 
 before_install:


### PR DESCRIPTION
build failed because -lgcov fails in the linking stage

apparently -lprofile_rt is needed on macos, but the autoconf macro does not pick that up

For now, will just disable coverage on osx