### PR TITLE
issue 45: Fix s390x / Big-Endian Issues

### DIFF
--- a/src/crcx.c
+++ b/src/crcx.c
@@ -168,7 +168,7 @@ bool crcx_generate_table(struct crcx_ctx *ctx) {
 bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t init, uintmax_t fini,
                uintmax_t poly, bool reflect_input, bool reflect_output) {
 
-  SET(uintmax_t, ctx->n, n);
+  SET(uint8_t, ctx->n, n);
   SET(uintmax_t, ctx->poly, poly);
   SET(bool, ctx->reflect_input, reflect_input);
   SET(bool, ctx->reflect_output, reflect_output);


### PR DESCRIPTION
The address "&ctx->n" was being cast to a uintmax_t in the SET() macro.

This was either a typo or a relic from a time when n was uintmax_t.