### PR TITLE
issue 55: refactor polynomial parameter placement in crcx init

### DIFF
--- a/src/crcx.c
+++ b/src/crcx.c
@@ -165,8 +165,8 @@ bool crcx_generate_table(struct crcx_ctx *ctx) {
 
 #define SET(t, k, v) *((t *)(&(k))) = (v)
 
-bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t init, uintmax_t fini,
-               uintmax_t poly, bool reflect_input, bool reflect_output) {
+bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t poly, uintmax_t init,
+               uintmax_t fini, bool reflect_input, bool reflect_output) {
 
   SET(uint8_t, ctx->n, n);
   SET(uintmax_t, ctx->poly, poly);

--- a/src/crcx/crcx.h
+++ b/src/crcx/crcx.h
@@ -37,7 +37,7 @@
  *   struct crcx_ctx ctx = {};
  *   // Initialize an 8-bit CRC with no initializer or finalizer, where
  *   // neither the input or output is reflected (in that order).
- *   crcx_init(&ctx, 8, 0, 0, 0x07, false, false);
+ *   crcx_init(&ctx, 8, 0x07, 0, 0, false, false);
  *   crcx(&ctx, data, sizeof(data));
  *   uintmax_t crc = crcx_fini(&ctx);
  *   // The value of crc should be 0xa2.
@@ -128,17 +128,17 @@ bool crcx_generate_table(struct crcx_ctx *ctx);
  *
  * @param ctx             the CRC context to initialize
  * @param n               number of bits in CRC. For E.g. CRC-8 use 8.
+ * @param poly            the polynomial used for CRC calculations
  * @param init            initial value stored in the @ref crcx_ctx.lfsr
  * @param fini            final value xor'ed with the @ref crcx_ctx.lfsr
- * @param poly            the polynomial used for CRC calculations
  * @param reflect_input   perform a bitwise reversal of each input byte
  * @param reflect_output  perform a bitwise reversal of the result of the CRC
  * calculation
  *
  * @return true on success, otherwise false
  */
-bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t init, uintmax_t fini,
-               uintmax_t poly, bool reflect_input, bool reflect_output);
+bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t poly, uintmax_t init,
+               uintmax_t fini, bool reflect_input, bool reflect_output);
 
 /**
  * Finalize a CRC context

--- a/test/crc3x-test.cpp
+++ b/test/crc3x-test.cpp
@@ -338,7 +338,8 @@ TEST(LibCRC3x, board_example1) {
 TEST(LibCRC3x, nrf_support1) {
   // https://devzone.nordicsemi.com/f/nordic-q-a/679/ble-crc-calculation
 
-  // oddly getting "non-trivial designated initializers not supported" error only on s390x
+  // oddly getting "non-trivial designated initializers not supported" error
+  // only on s390x
   pdu_adv pdu = {};
   pdu.type = ADV_IND;
   pdu.len = 9;
@@ -374,7 +375,8 @@ TEST(LibCRC3x, nrf_support1) {
 TEST(LibCRC3x, ble_core_52_4_2_1_Legacy_Advertising_PDUs) {
   // https://www.bluetooth.com/specifications/bluetooth-core-specification/
 
-  // oddly getting "non-trivial designated initializers not supported" error only on s390x
+  // oddly getting "non-trivial designated initializers not supported" error
+  // only on s390x
   pdu_adv pdu = {};
   pdu.type = ADV_NONCONN_IND;
   pdu.tx_addr = 1;

--- a/test/crcx-test.cpp
+++ b/test/crcx-test.cpp
@@ -232,7 +232,7 @@ TEST(LibCRCx, Wikipedia_example1) {
 
   ::crcx_ctx ctx = {};
 
-  ASSERT_TRUE(::crcx_init(&ctx, 8, 0, 0, 0b100000111, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 8, 0b100000111, 0, 0, false, false));
 
   ASSERT_EQ(ctx.n, 8);
   ASSERT_EQ(ctx.msb, 0x80);
@@ -292,7 +292,7 @@ TEST(LibCRCx, Sunshine_CRC8) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 8, 0, 0, 0x07, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 8, 0x07, 0, 0, false, false));
 
   ASSERT_TRUE(::crcx(&ctx, &data.front(), data.size()));
 
@@ -318,7 +318,7 @@ TEST(LibCRCx, Sunshine_CRC8_ITU) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 8, 0, 0x55, 0x07, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 8, 0x07, 0, 0x55, false, false));
 
   ASSERT_TRUE(::crcx(&ctx, &data.front(), data.size()));
 
@@ -344,7 +344,7 @@ TEST(LibCRCx, Sunshine_CRC8_DARC) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 8, 0, 0, 0x39, true, true));
+  ASSERT_TRUE(::crcx_init(&ctx, 8, 0x39, 0, 0, true, true));
 
   ASSERT_TRUE(::crcx(&ctx, &data.front(), data.size()));
 
@@ -369,7 +369,7 @@ TEST(LibCRCx, Sunshine_CRC16_CCIT_ZERO_one_byte) {
   const vector<uint8_t> data{uint8_t('W')};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 16, 0, 0, 0x1021, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 16, 0x1021, 0, 0, false, false));
 
   ASSERT_EQ(ctx.n, 16);
   ASSERT_EQ(ctx.msb, 0x8000);
@@ -438,7 +438,7 @@ TEST(LibCRCx, Sunshine_CRC16_CCIT_ZERO_incremental) {
   // checking intermediate values.
 
   // the lfsr value is now 0, then, 0x2672, 0x20b5, ...
-  ASSERT_TRUE(::crcx_init(&ctx, 16, 0, 0, 0x1021, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 16, 0x1021, 0, 0, false, false));
 
   ASSERT_TRUE(data.size() == expected.size());
   for (size_t i = 0; i < data.size(); ++i) {
@@ -468,7 +468,7 @@ TEST(LibCRCx, Sunshine_CRC16_CCIT_ZERO) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 16, 0, 0, 0x1021, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 16, 0x1021, 0, 0, false, false));
 
   // clang-format off
     auto expected_v = to_vector(
@@ -518,7 +518,7 @@ TEST(LibCRCx, Sunshine_CRC32_POSIX) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 32, 0, -1, 0x4c11db7, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 32, 0x4c11db7, 0, -1, false, false));
 
   // clang-format off
     auto expected_v = to_vector(
@@ -584,7 +584,7 @@ TEST(LibCRCx, Sunshine_CRC64_ECMA_182) {
                              0x36, 0x37, 0x38, 0x39};
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, 64, 0, 0, 0x42F0E1EBA9EA3693, false, false));
+  ASSERT_TRUE(::crcx_init(&ctx, 64, 0x42F0E1EBA9EA3693, 0, 0, false, false));
 
   // clang-format off
     auto expected_v = to_vector(
@@ -724,7 +724,7 @@ TEST(LibCRCx, board_example1) {
   const uint32_t wireshark_crc(0x0801bd);
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_init, ble_fini, ble_poly,
+  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_poly, ble_init, ble_fini,
                           ble_reflect_input, ble_reflect_output));
   ASSERT_TRUE(::crcx(&ctx, data, len));
   uintmax_t sw_crc = ::crcx_fini(&ctx);
@@ -739,7 +739,8 @@ TEST(LibCRCx, board_example1) {
 TEST(LibCRCx, nrf_support1) {
   // https://devzone.nordicsemi.com/f/nordic-q-a/679/ble-crc-calculation
 
-  // oddly getting "non-trivial designated initializers not supported" error only on s390x
+  // oddly getting "non-trivial designated initializers not supported" error
+  // only on s390x
   pdu_adv pdu = {};
   pdu.type = ADV_IND;
   pdu.len = 9;
@@ -759,7 +760,7 @@ TEST(LibCRCx, nrf_support1) {
   const size_t pdu_len = PDU_AC_LL_HEADER_SIZE + pdu.len;
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_init, ble_fini, ble_poly,
+  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_poly, ble_init, ble_fini,
                           ble_reflect_input, ble_reflect_output));
   ASSERT_TRUE(::crcx(&ctx, &pdu, pdu_len));
   uintmax_t expected_uintmax = ::crcx_reflect(0xa4e2c2, ctx.n);
@@ -774,7 +775,8 @@ TEST(LibCRCx, nrf_support1) {
 TEST(LibCRCx, ble_core_52_4_2_1_Legacy_Advertising_PDUs) {
   // https://www.bluetooth.com/specifications/bluetooth-core-specification/
 
-  // oddly getting "non-trivial designated initializers not supported" error only on s390x
+  // oddly getting "non-trivial designated initializers not supported" error
+  // only on s390x
   pdu_adv pdu = {};
   pdu.type = ADV_NONCONN_IND;
   pdu.tx_addr = 1;
@@ -795,7 +797,7 @@ TEST(LibCRCx, ble_core_52_4_2_1_Legacy_Advertising_PDUs) {
   const size_t pdu_len = PDU_AC_LL_HEADER_SIZE + pdu.len;
 
   ::crcx_ctx ctx = {};
-  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_init, ble_fini, ble_poly,
+  ASSERT_TRUE(::crcx_init(&ctx, ble_crc_n, ble_poly, ble_init, ble_fini,
                           ble_reflect_input, ble_reflect_output));
   ASSERT_TRUE(::crcx(&ctx, &pdu, pdu_len));
   uintmax_t expected_uintmax = 0xb52dd7;


### PR DESCRIPTION
The Crc3x C++ class orders template parameters as <type, N, poly>. However, the crcx_init() API call orders parameters as crcx_init (struct crcx_ctx *ctx, uint8_t n, uintmax_t init, uintmax_t fini, uintmax_t poly, bool reflect_input, bool reflect_output).

It would probably be more intuitive to modify the C api to be crcx_init (struct crcx_ctx *ctx, uint8_t n, uintmax_t poly, uintmax_t init, uintmax_t fini, bool reflect_input, bool reflect_output) and would be a bit more consistent with the C++ API

This fixes #55

Signed-off-by: Christopher Friedt <chrisfriedt@gmail.com>