### PR TITLE
issue 16: support cmake

### DIFF
--- a/.scripts/build-and-install-libgtest-libraries.sh
+++ b/.scripts/build-and-install-libgtest-libraries.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 # N.B. Older Ubuntu versions do not carry the "googletest" package
 # (which includes Google Mock and Google Test), so better to just
@@ -13,17 +14,34 @@ git clone https://github.com/google/googletest.git
 cd googletest
 
 # for some reason this doesn't work
-#if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-if [ "Darwin" = "$(uname)" ]; then
-  # /usr is read-only on macos, even with sudo
-  PREFIX="/usr/local"
-else
-  PREFIX="/usr"
-fi
+case "$(uname)" in
+  Darwin)
+    # /usr is read-only on macos, even with sudo
+    PREFIX="/usr/local"
+  ;;
+  *)
+    PREFIX="/usr"
+  ;;
+esac
 
-# installs headers to /usr/include/gtest /usr/include/gmock
-# install static libraries to /usr/lib
-cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17  -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} . && make -j$(nproc --all) all install
-# install shared libraries to /usr/lib
-cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} -DBUILD_SHARED_LIBS=ON && make -j$(nproc --all) all install
-
+# for some reason this doesn't work
+case "$(uname)" in
+  Darwin|Linux)
+    # installs headers to /usr/include/gtest /usr/include/gmock
+    # install static libraries to /usr/lib
+    cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} .
+    make -j$(nproc --all) all install
+    # install shared libraries to /usr/lib
+    cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} -DBUILD_SHARED_LIBS=ON .
+    make -j$(nproc --all) all install
+  ;;
+  *)
+    # installs headers to /usr/include/gtest /usr/include/gmock
+    # install static libraries to /usr/lib
+    cmake -G"MSYS Makefiles" -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} .
+    mingw32-make -j$(nproc --all) all install
+    # install shared libraries to /usr/lib
+    cmake -G"MSYS Makefiles" -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} -DBUILD_SHARED_LIBS=ON .
+    mingw32-make -j$(nproc --all) all install
+  ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,49 +122,50 @@ matrix:
     if: tag IS blank
   - os: osx
     if: tag IS blank
+  - arch: ppcle64
+    if: tag IS blank
+  - arch: s390x
+    if: tag IS blank
+  - arch: arm64
+    if: tag IS blank
 
 before_install:
+  - eval "${MATRIX_EVAL}"
+
+before_script:
 - |-
     case $TRAVIS_OS_NAME in
-      linux)
-        eval "${MATRIX_EVAL}"
-        ;;
-      osx)
-        eval "${MATRIX_EVAL}"
+      linux|osx)
+        sudo sh .scripts/build-and-install-libgtest-libraries.sh
         ;;
       windows)
-        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
-        choco uninstall -y mingw
-        choco upgrade --no-progress -y msys2
-        export msys2='cmd //C RefreshEnv.cmd '
-        export msys2+='& set MSYS=winsymlinks:nativestrict '
-        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
-        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
-        export msys2+=" -msys2 -c "\"\$@"\" --"
-        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
-        ## Install more MSYS2 packages from https://packages.msys2.org/base here
-        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
-        export PATH=/C/tools/msys64/mingw64/bin:$PATH
-        export MAKE=mingw32-make  # so that Autotools can find it
+        export PATH="${PATH}:/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin"
         ;;
     esac
 
-before_script:
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then ${SUDO} sh .scripts/build-and-install-libgtest-libraries.sh; fi
-
 script:
-  - autoreconf -vfi
-  - ./configure ${OPTS}
-  - make -j`nproc --all`
-  - make check
-  - ${SUDO} ${MAKE} -j`nproc --all` install
-  - # ensure a simple application can compile and link to libcrcx
-  - echo 'extern void crcx_init(); int main() { crcx_init(); return 0; }' > foo.c
-  - ${CC} -o foo foo.c `pkg-config --cflags --libs crcx`
-  - # ensure a simple application can compile and link to libcrcxxx
-  - echo '#include <crc3x/crc3x.h>' > foo.cpp
-  - echo 'using namespace ::crc3x; int main() { using Crc3x = Crc<uint8_t,8,7>; Crc3x crc(0,0,false,false); return 0; }' >> foo.cpp
-  - ${CXX} -std=c++17 -o foo foo.cpp `pkg-config --cflags --libs crc3x`
+- |-
+    case $TRAVIS_OS_NAME in
+      linux|osx)
+        eval "${MATRIX_EVAL}"
+        autoreconf -vfi
+        ./configure ${OPTS}
+        make -j`nproc --all`
+        make check
+        ${SUDO} ${MAKE} -j`nproc --all` install
+        # ensure a simple application can compile and link to libcrcx
+        echo 'extern void crcx_init(); int main() { crcx_init(); return 0; }' > foo.c
+        ${CC} -o foo foo.c `pkg-config --cflags --libs crcx`
+        # ensure a simple application can compile and link to libcrc3x
+        echo '#include <crc3x/crc3x.h>' > foo.cpp
+        echo 'using namespace ::crc3x; int main() { using Crc3x = Crc<uint8_t,8,7>; Crc3x crc(0,0,false,false); return 0; }' >> foo.cpp
+        ${CXX} -std=c++17 -o foo foo.cpp `pkg-config --cflags --libs crc3x`
+        ;;
+      windows)
+        cmake .
+        msbuild.exe crcx.sln
+        ;;
+    esac
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required (VERSION 3.0)
+
+project(crcx VERSION 0.2 LANGUAGES C CXX)
+
+add_subdirectory (src)
+
+enable_testing()
+add_subdirectory (test)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A simple, straightforward [CRC](https://en.wikipedia.org/wiki/Cyclic_redundancy_
 
 ## Build Matrix
 
-| (OS, Compiler) | amd64            | ppc64le            | s390x             | arm64             |
-|----------------|------------------|--------------------|-------------------|-------------------|
-| (Linux, gcc)   | [![amd64][2]][1] | [![ppc64le][3]][1] | [![s390x][4]][1]  | [![arm64][5]][1]  |
-| (Linux, clang) | [![amd64][6]][1] | [![ppc64le][7]][1] | [![s390x][8]][1] | [![arm64][9]][1] |
-| (macOS, clang) | [![amd64][10]][1] |                    |                   |                   |
-| (Windows, gcc) | [![amd64][11]][1] |                    |                   |                   |
+| (OS, Compiler)  | amd64             | ppc64le            | s390x             | arm64             |
+|-----------------|-------------------|--------------------|-------------------|-------------------|
+| (Linux, gcc)    | [![amd64][2]][1]  | [![ppc64le][3]][1] | [![s390x][4]][1]  | [![arm64][5]][1]  |
+| (Linux, clang)  | [![amd64][6]][1]  | [![ppc64le][7]][1] | [![s390x][8]][1]  | [![arm64][9]][1]  |
+| (macOS, clang)  | [![amd64][10]][1] |                    |                   |                   |
+| (Windows, msvc) | [![amd64][11]][1] |                    |                   |                   |
 
 [1]: https://travis-ci.com/cfriedt/crcx
 [2]: https://travis-matrix-badges.herokuapp.com/repos/cfriedt/crcx/branches/master/1?use_travis_com=true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+add_library (crcx crcx.c)
+add_library (crc3x crc3x.cpp)
+set_property(TARGET crc3x PROPERTY CXX_STANDARD 17)

--- a/src/crcx/_cdefs.h
+++ b/src/crcx/_cdefs.h
@@ -1,0 +1,12 @@
+#ifndef CRCX__CDEFS_H_
+#define CRCX__CDEFS_H_
+
+#ifdef __cplusplus
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
+#else
+#define __BEGIN_DECLS
+#define __END_DECLS
+#endif /* __cplusplus */
+
+#endif /* CRCX__CDEFS_H_ */

--- a/src/crcx/crcx.h
+++ b/src/crcx/crcx.h
@@ -53,7 +53,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifdef _MSC_VER
+#include <crcx/_cdefs.h>
+#else
 #include <sys/cdefs.h>
+#endif
 
 __BEGIN_DECLS
 
@@ -164,7 +168,7 @@ uintmax_t crcx_fini(struct crcx_ctx *ctx);
  * @param ctx   the CRC context to update
  * @param data  the data for which the CRC should be updated
  */
-void crcx_update(struct crcx_ctx *ctx, const uint8_t data);
+void crcx_update(struct crcx_ctx *ctx, uint8_t data);
 
 /**
  * Compute the CRC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_policy(SET CMP0048 NEW)
+
+find_package(PkgConfig)
+
+if(PKG_CONFIG_FOUND) 
+
+pkg_search_module(GTEST REQUIRED gtest_main)
+
+if(GTEST_FOUND)
+
+add_executable (crcx-test crcx-test.cpp)
+add_test (NAME crcx-test COMMAND crcx-test)
+target_include_directories (crcx-test PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_compile_options (crcx-test PUBLIC ${GTEST_CFLAGS})
+target_link_libraries (crcx-test LINK_PUBLIC crcx ${GTEST_LDFLAGS})
+
+add_executable (crc3x-test crc3x-test.cpp)
+add_test (NAME crc3x-test COMMAND crc3x-test)
+target_include_directories (crc3x-test PUBLIC ${CMAKE_SOURCE_DIR}/src)
+set_property(TARGET crc3x-test PROPERTY CXX_STANDARD 17)
+target_compile_options (crc3x-test PUBLIC ${GTEST_CFLAGS})
+target_link_libraries (crc3x-test LINK_PUBLIC crcx ${GTEST_LDFLAGS})
+
+endif()
+endif()


### PR DESCRIPTION
CMake is a fairly popular build system. It's far simpler to use it on a Windows host than it is to download, set up, and use autotools.

Fixes #16 
Fixes #60 

Signed-off-by: Christopher Friedt <chrisfriedt@gmail.com>