### PR TITLE
crcx crc3x: fini methods should reinitialize the lfsr

### DIFF
--- a/src/crc3x/crc3x.h
+++ b/src/crc3x/crc3x.h
@@ -266,17 +266,26 @@ public:
    * This function xor's the @p Crc.lfsr with the value specified by @p
    * Crc.finalizer.
    *
-   * This function reflects the input data if specified by @p Crc.reflectInput.
+   * This function reflects the output if specified by @p Crc.reflectOutput.
+   * 
+   * This function also re-initializes the @p Crc.lfsr with the value
+   * specified by @p Crc.initializer.
+   * 
+   * @return The result of the CRC algorithm
    */
   T fini() {
+    T result;
     lfsr ^= finalizer;
     lfsr &= generator<T, N, polynomial>::mask();
 
     if (reflectOutput) {
-      return reflect(lfsr, N);
+      result = reflect(lfsr, N);
     } else {
-      return lfsr;
+      result = lfsr;
     }
+
+    lfsr = initializer;
+    return result;
   }
 
 protected:

--- a/src/crcx.c
+++ b/src/crcx.c
@@ -199,6 +199,7 @@ bool crcx_init(struct crcx_ctx *ctx, uint8_t n, uintmax_t poly, uintmax_t init,
 }
 
 uintmax_t crcx_fini(struct crcx_ctx *ctx) {
+  uintmax_t r;
 
   if (!crcx_valid(ctx)) {
     return -1;
@@ -213,7 +214,10 @@ uintmax_t crcx_fini(struct crcx_ctx *ctx) {
     D("lfsr: %" PRIxMAX, ctx->lfsr);
   }
 
-  return ctx->lfsr;
+  r = ctx->lfsr;
+  ctx->lfsr = ctx->init;
+
+  return r;
 }
 
 void crcx_update(struct crcx_ctx *ctx, uint8_t data) {

--- a/src/crcx/crcx.h
+++ b/src/crcx/crcx.h
@@ -174,7 +174,8 @@ void crcx_update(struct crcx_ctx *ctx, uint8_t data);
  * Compute the CRC
  *
  * This function should be called after @ref crcx_init and before @ref
- * crcx_fini.
+ * crcx_fini. Or, if performing multiple successive CRC calculations, it
+ * can be called again after @ref crcx_fini.
  *
  * It validates input with @ref crcx_valid and then calls @ref crcx_update
  * @p len times, once for each item in @p data.


### PR DESCRIPTION
The LFSR (Linear Feedback Shift Register) holds all of the state necessary for the CRC to be either updated with a new value or finalized.

When the CRC is finalized, the LFSR should be reset to the initialization value so that the same CRC object or context can be reused for repeated, successive CRC computation.

Fixes #64